### PR TITLE
Create config file symlink with `aiq workflow create` command

### DIFF
--- a/src/aiq/cli/commands/workflow/workflow_commands.py
+++ b/src/aiq/cli/commands/workflow/workflow_commands.py
@@ -123,8 +123,8 @@ def get_workflow_path_from_name(workflow_name: str):
 @click.option(
     "--workflow-dir",
     default=".",
-    help="Output directory for saving the created workflow. A new folder with the workflow name will be created within."
-    "Defaults to the present working directory.")
+    help="Output directory for saving the created workflow. A new folder with the workflow name will be created "
+    "within. Defaults to the present working directory.")
 @click.option(
     "--description",
     default="AIQ Toolkit function template. Please update the description.",
@@ -170,6 +170,8 @@ def create_command(workflow_name: str, install: bool, workflow_dir: str, descrip
         (new_workflow_dir / 'src' / package_name).mkdir(parents=True)
         # Create config directory
         (new_workflow_dir / 'src' / package_name / 'configs').mkdir(parents=True)
+        # Create package level configs directory
+        (new_workflow_dir / 'configs').mkdir(parents=True)
 
         # Initialize Jinja2 environment
         env = Environment(loader=FileSystemLoader(str(template_dir)))
@@ -196,7 +198,6 @@ def create_command(workflow_name: str, install: bool, workflow_dir: str, descrip
             'python_safe_workflow_name': workflow_name.replace("-", "_"),
             'package_name': package_name,
             'rel_path_to_repo_root': rel_path_to_repo_root,
-            # 'workflow_class_name': f"{workflow_name.capitalize().replace("-", "").replace("_", "")}WorkflowConfig",
             'workflow_class_name': f"{_generate_valid_classname(workflow_name)}FunctionConfig",
             'workflow_description': description
         }
@@ -206,6 +207,11 @@ def create_command(workflow_name: str, install: bool, workflow_dir: str, descrip
             content = template.render(context)
             with open(output_path, 'w', encoding="utf-8") as f:
                 f.write(content)
+
+        # Create symlink for config.yml
+        config_source = new_workflow_dir / 'src' / package_name / 'configs' / 'config.yml'
+        config_link = new_workflow_dir / 'configs' / 'config.yml'
+        os.symlink(config_source, config_link)
 
         if install:
             # Install the new package without changing directories


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes: https://github.com/NVIDIA/AIQToolkit/issues/165

This PR creating symlinks to the placeholder config.yml file created by the `aiq workflow create` command and provides familiar package structure as the examples. This config file is contained in a folder at the generated package root directory. The package hierarchy has the following structure:

```
my_sample_workflow/
├── configs
│   └── config.yml -> /path/to/my_sample_workflow/src/my_sample_workflow/configs/config.yml
├── pyproject.toml
└── src
    ├── my_sample_workflow
    │   ├── configs
    │   │   └── config.yml
    │   ├── __init__.py
    │   ├── my_sample_workflow_function.py
    │   └── register.py
    └── my_sample_workflow.egg-info
        ├── dependency_links.txt
        ├── entry_points.txt
        ├── PKG-INFO
        ├── requires.txt
        ├── SOURCES.txt
        └── top_level.txt
```

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
