### PR TITLE
CLI Documentation fixes in remote registry configuration section

### DIFF
--- a/docs/source/concepts/cli.md
+++ b/docs/source/concepts/cli.md
@@ -494,7 +494,7 @@ Search Route: simple  # The route use when searching for relevant AIQ Toolkit pa
 #### Updating a Remote Registry Channel Configuration
 
 At some point, a developer might need to update a remote registry channel's configuration settings. In this case,
-using the `aiq configure registry update` command will select a remote registry by its locally unique name and allow
+using the `aiq configure channel update` command will select a remote registry channel by its locally unique name and allow
 the developer to override the configuration settings.
 
 A usage example is provided below:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes https://github.com/NVIDIA/AIQToolkit/issues/183

This PR fixes errors in the CLI documentation. The section that describes the CLI commands to update locally configured remote registry channels is incorrect.

The following command changes are implemented:

`aiq configure registry update` is modified to `aiq configure channel update`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
