### PR TITLE
fix typo in evaluate documentation for max_concurrency

### DIFF
--- a/docs/source/concepts/evaluate.md
+++ b/docs/source/concepts/evaluate.md
@@ -276,11 +276,11 @@ aiq eval --config_file=examples/simple/configs/eval_config.yml --reps=5
 This will allow you to get an average score across multiple runs and analyze the variation in the generated outputs.
 
 ## Running evaluation on large datasets
-Similar to how evaluators are run in parallel, entries in the dataset are also processed in parallel. Concurrency is configurable using the `eval.general.concurrency` parameter in the `config.yml` file. The default value is 8. Increase or decrease the value based on the available resources.
+Similar to how evaluators are run in parallel, entries in the dataset are also processed in parallel. Concurrency is configurable using the `eval.general.max_concurrency` parameter in the `config.yml` file. The default value is 8. Increase or decrease the value based on the available resources.
 ```yaml
 eval:
   general:
-    concurrency: 4
+    max_concurrency: 4
 ```
 
 ## Pickup where you left off


### PR DESCRIPTION
## Description
changed `concurrency` to `max_concurrency` in config parameters of _evaluate.md_

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
