### PR TITLE
Config option to specify the intermediate step types in workflow_output.json

### DIFF
--- a/docs/source/concepts/evaluate.md
+++ b/docs/source/concepts/evaluate.md
@@ -370,6 +370,18 @@ The output of the evaluators are stored in distinct files in the same `output_di
 }
 ```
 
+## Workflow Output Intermediate Step Filtering
+The workflow_output.json file contains the intermediate steps for each entry in the dataset. The intermediate steps are filtered using the `eval.general.output.workflow_output_step_filter` parameter in the `config.yml` file. The default value for the filter is `[LLM_END, TOOL_END]`. You can customize the filter by providing a list of intermediate step types to include in the output file.
+
+**Example:**
+`examples/simple/configs/eval_config.yml` can be modified to include the intermediate steps in the output by adding the following configuration:
+```yaml
+eval:
+  general:
+    output:
+    workflow_output_step_filter: [LLM_END, TOOL_START, TOOL_END]
+```
+
 ## Customizing the output
 You can customize the output of the pipeline by providing custom scripts. One or more Python scripts can be provided in the `eval.general.output_scripts` section of the `config.yml` file.
 

--- a/src/aiq/data_models/evaluate.py
+++ b/src/aiq/data_models/evaluate.py
@@ -24,6 +24,7 @@ from aiq.data_models.common import TypedBaseModel
 from aiq.data_models.dataset_handler import EvalDatasetConfig
 from aiq.data_models.dataset_handler import EvalS3Config
 from aiq.data_models.evaluator import EvaluatorBaseConfig
+from aiq.data_models.intermediate_step import IntermediateStepType
 from aiq.data_models.profiler import ProfilerConfig
 
 
@@ -45,6 +46,8 @@ class EvalOutputConfig(BaseModel):
     s3: EvalS3Config | None = None
     # Whether to cleanup the output directory before running the workflow
     cleanup: bool = True
+    # Filter for the workflow output steps
+    workflow_output_step_filter: list[IntermediateStepType] | None = None
 
 
 class EvalGeneralConfig(BaseModel):

--- a/src/aiq/eval/evaluate.py
+++ b/src/aiq/eval/evaluate.py
@@ -177,7 +177,8 @@ class EvaluationRun:  # pylint: disable=too-many-public-methods
         workflow_output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Write the workflow output to a file (this can be used for re-running the evaluation)
-        workflow_output = dataset_handler.publish_eval_input(self.eval_input)
+        workflow_output = dataset_handler.publish_eval_input(
+            self.eval_input, self.eval_config.general.output.workflow_output_step_filter)
         with open(workflow_output_file, "w", encoding="utf-8") as f:
             # set indent to 2 for pretty printing
             f.write(workflow_output)


### PR DESCRIPTION
Currently, only TOOL_OUTPUT and LLM_OUTPUT are included in the published workflow_output.json. But there are usecases where other types such as TOOL_START may asl be needed.  This PR provides a config option in config.yml to allow the user to specify the filter.

Sample config (examples/simple/configs/eval_config.yml):
```
    eval:
      general:
        output:
          dir: ./.tmp/aiq/examples/simple/
          workflow_output_step_filter: [LLM_END, TOOL_START, TOOL_END]
```

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
