### PR TITLE
Check if request is present before setting attributes

### DIFF
--- a/src/aiq/runtime/session.py
+++ b/src/aiq/runtime/session.py
@@ -123,7 +123,11 @@ class AIQSessionManager:
     def set_request_attributes(self, request: Request) -> None:
         """
         Extracts and sets request attributes from an HTTP request.
+        If request is None, no attributes are set.
         """
+        if request is None:
+            return
+
         self._context.metadata._request.method = request.method
         self._context.metadata._request.url_path = request.url.path
         self._context.metadata._request.url_port = request.url.port


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Steps to repro:
Install latest AiqToolKit from source and run the simple-calculator example:
```
aiq run --config_file examples/simple_cal
culator/configs/config.yml --input "What is the product of 3 and 7, and is it greater than the curre
nt hour?"
```

Following traceback is seen:
```
2025-05-05 11:18:30,130 - aiq.cli.commands.start - ERROR - Failed to initialize workflow
Traceback (most recent call last):
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/cli/commands/start.py", line 229, in invoke_subcommand
    return asyncio.run(run_plugin())
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/agentiq/.venv/lib/python3.12/site-packages/nest_asyncio.py", line 30, in run
    return loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/agentiq/.venv/lib/python3.12/site-packages/nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ^^^^^^^^^^
  File "/home/devcontainers/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/futures.py", line 202, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/home/devcontainers/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/tasks.py", line 316, in __step_run_and_handle_result
    result = coro.throw(exc)
             ^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/cli/commands/start.py", line 227, in run_plugin
    await front_end_plugin.run()
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/front_ends/console/console_front_end_plugin.py", line 74, in run
    await self.run_workflow(session_manager)
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/front_ends/console/console_front_end_plugin.py", line 94, in run_workflow
    runner_outputs = await asyncio.gather(*[run_single_query(query) for query in input_list])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/tasks.py", line 385, in __wakeup
    future.result()
  File "/home/devcontainers/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/tasks.py", line 314, in __step_run_and_handle_result
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/front_ends/console/console_front_end_plugin.py", line 84, in run_single_query
    async with session_manager.session(user_input_callback=prompt_for_input_cli) as session:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/runtime/session.py", line 100, in session
    self.set_request_attributes(request)
  File "/home/devcontainers/dev/forks/agentiq/src/aiq/runtime/session.py", line 127, in set_request_attributes
    self._context.metadata._request.method = request.method
                                             ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'method'
Error: 'NoneType' object has no attribute 'method'
```

This PR adds a sanity check to prevent request access unless it is present.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
