### PR TITLE
Treat a tagged commit the same as a nightly build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,3 +128,4 @@ upload:artifactory:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_COMMIT_BRANCH == 'main'
+    - if: $CI_COMMIT_TAG

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -29,10 +29,10 @@ else
    NEXT_VERSION=$1
 fi
 
-export SCRIPT_DIR=${SCRIPT_DIR:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"}
+export CUR_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # The root to the AIQ Toolkit repo
-export PROJECT_ROOT=${PROJECT_ROOT:-"$(realpath ${SCRIPT_DIR}/../..)"}
+export PROJECT_ROOT=${PROJECT_ROOT:-"$(realpath ${CUR_DIR}/../..)"}
 
 NEXT_MAJOR=$(echo ${NEXT_VERSION} | awk '{split($0, a, "."); print a[1]}')
 NEXT_MINOR=$(echo ${NEXT_VERSION} | awk '{split($0, a, "."); print a[2]}')
@@ -58,14 +58,14 @@ AIQ_PACKAGE_TOMLS=($(find ./packages -name "pyproject.toml" | sort ))
 AIQ_EXAMPLE_TOMLS=($(find ./examples -name "pyproject.toml" | sort ))
 
 for TOML_FILE in ${AIQ_EXAMPLE_TOMLS[@]}; do
-    ${SCRIPT_DIR}/update_toml_dep.py \
+    ${CUR_DIR}/update_toml_dep.py \
       --toml-file-path=${TOML_FILE} \
       --new-version="${AIQ_VERSION}" \
       --version-match="${VERSION_MATCH}"
 done
 
 for TOML_FILE in "${AIQ_PACKAGE_TOMLS[@]}"; do
-    ${SCRIPT_DIR}/update_toml_dep.py \
+    ${CUR_DIR}/update_toml_dep.py \
       --toml-file-path=${TOML_FILE} \
       --new-version="${AIQ_VERSION}" \
       --version-match="${VERSION_MATCH}"

--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -21,9 +21,13 @@ GITLAB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 
 source ${GITLAB_SCRIPT_DIR}/common.sh
 
+GIT_TAG=$(get_git_tag)
+IS_TAGGED=$(is_current_commit_tagged)
+rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
+
 # change this to ready to publish. this should be done programmatically once
 # the release process is finalized.
-if [[ "${CI_CRON_NIGHTLY}" == "1" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "0" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
     RELEASE_STATUS=ready
 else
     RELEASE_STATUS=preview
@@ -39,9 +43,6 @@ WHEELS_BASE_DIR="${CI_PROJECT_DIR}/.tmp/wheels"
 
 # Define the subdirectories to be exclude
 EXCLUDE_SUBDIRS=("examples")
-
-GIT_TAG=$(get_git_tag)
-rapids-logger "Git Version: ${GIT_TAG}"
 
 # Exit if required secrets are not set
 if [[ -z "${URM_USER}" || -z "${URM_API_KEY}" ]]; then
@@ -93,7 +94,7 @@ if [[ "${UPLOAD_TO_ARTIFACTORY}" == "true" ]]; then
 
         for SUBDIR in $(find "${WHEELS_DIR}" -mindepth 1 -maxdepth 1 -type d); do
             SUBDIR_NAME=$(basename "${SUBDIR}")
-            
+
             # Skip directories listed in EXCLUDE_SUBDIRS
             if [[ " ${EXCLUDE_SUBDIRS[@]} " =~ " ${SUBDIR_NAME} " ]]; then
                 echo "Skipping excluded directory: ${SUBDIR_NAME}"

--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -27,7 +27,7 @@ rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
 # change this to ready to publish. this should be done programmatically once
 # the release process is finalized.
-if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "0" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "1" || "${CI_COMMIT_BRANCH}" == "main" ]]; then
     RELEASE_STATUS=ready
 else
     RELEASE_STATUS=preview

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -24,7 +24,7 @@ GIT_TAG=$(get_git_tag)
 IS_TAGGED=$(is_current_commit_tagged)
 rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
-if [[ "${CI_CRON_NIGHTLY}" == "1" || ( ${IS_TAGGED} == "0" && "${CI_COMMIT_BRANCH}" != "main" ) ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || ( ${IS_TAGGED} == "1" && "${CI_COMMIT_BRANCH}" != "main" ) ]]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
     export USE_FULL_VERSION="1"
     ${PROJECT_ROOT}/ci/release/update-version.sh "${GIT_TAG}"

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -27,6 +27,7 @@ rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 if [[ "${CI_CRON_NIGHTLY}" == "1" || ( ${IS_TAGGED} == "1" && "${CI_COMMIT_BRANCH}" != "main" ) ]]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
     export USE_FULL_VERSION="1"
+    create_env group:dev
     ${PROJECT_ROOT}/ci/release/update-version.sh "${GIT_TAG}"
 fi
 

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -21,9 +21,10 @@ GITLAB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 source ${GITLAB_SCRIPT_DIR}/common.sh
 
 GIT_TAG=$(get_git_tag)
-rapids-logger "Git Version: ${GIT_TAG}"
+IS_TAGGED=$(is_current_commit_tagged)
+rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
-if [[ "${CI_CRON_NIGHTLY}" == "1" ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "0" ]]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
     export USE_FULL_VERSION="1"
     ${PROJECT_ROOT}/ci/release/update-version.sh "${GIT_TAG}"

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -24,7 +24,7 @@ GIT_TAG=$(get_git_tag)
 IS_TAGGED=$(is_current_commit_tagged)
 rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
-if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "0" ]]; then
+if [[ "${CI_CRON_NIGHTLY}" == "1" || ( ${IS_TAGGED} == "0" && "${CI_COMMIT_BRANCH}" != "main" ) ]]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
     export USE_FULL_VERSION="1"
     ${PROJECT_ROOT}/ci/release/update-version.sh "${GIT_TAG}"

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -32,9 +32,8 @@ function get_git_tag() {
             exit 1;
         fi
 
-        # If the branch is a nightly build create an alpha tag which will be accepted by pypi
-        # Note: We are intentionally not pushing this tag, it exists for the sole purpose of generating a
-        # unique alpha version for nightly builds.
+        # If the branch is a nightly build create a version which will be accepted by pypi
+        # Note: We are intentionally creating an actual tag, just setting the variable
         GIT_TAG=$(echo $GIT_TAG | sed -e "s|-dev|a$(date +"%Y%m%d")|")
     fi
 

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -40,8 +40,14 @@ function get_git_tag() {
     echo ${GIT_TAG}
 }
 
-
-
+function is_current_commit_tagged() {
+    # Check if the current commit is tagged
+    set +e
+    git describe --tags --exact-match HEAD >/dev/null 2>&1
+    local result=$?
+    set -e
+    echo ${result}
+}
 
 function create_env() {
 

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -34,7 +34,7 @@ function get_git_tag() {
 
         # If the branch is a nightly build create a version which will be accepted by pypi
         # Note: We are intentionally creating an actual tag, just setting the variable
-        GIT_TAG=$(echo $GIT_TAG | sed -e "s|-dev|a$(date +"%Y%m%d")|")
+        GIT_TAG=$(echo $GIT_TAG | sed -e "s|-.*|a$(date +"%Y%m%d")|")
     fi
 
     echo ${GIT_TAG}

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -44,9 +44,15 @@ function is_current_commit_tagged() {
     # Check if the current commit is tagged
     set +e
     git describe --tags --exact-match HEAD >/dev/null 2>&1
-    local result=$?
+    local status_code=$?
     set -e
-    echo ${result}
+
+    # Convert the unix status code to a boolean value
+    local is_tagged=0
+    if [[ ${status_code} -eq 0 ]]; then
+        is_tagged=1
+    fi
+    echo ${is_tagged}
 }
 
 function create_env() {


### PR DESCRIPTION
## Description
* Ensure that tagged (presumably rc tags) commits are marked as `ready`
* Ensure that tagged commits on the develop branch are treated the same as nightly builds and internal dependencies are fully specified (`aiqtoolkit==1.1.0rc2` rather than `aiqtoolkit~=1.1`)
* Fix handling of the version for nightly builds
* Fix out of date/incorrect/misleading comment

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
