### PR TITLE
Fix incorrect eval output config access

### DIFF
--- a/src/aiq/eval/evaluate.py
+++ b/src/aiq/eval/evaluate.py
@@ -177,8 +177,10 @@ class EvaluationRun:  # pylint: disable=too-many-public-methods
         workflow_output_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Write the workflow output to a file (this can be used for re-running the evaluation)
-        workflow_output = dataset_handler.publish_eval_input(
-            self.eval_input, self.eval_config.general.output.workflow_output_step_filter)
+
+        step_filter = self.eval_config.general.output.workflow_output_step_filter \
+            if self.eval_config.general.output else None
+        workflow_output = dataset_handler.publish_eval_input(self.eval_input, step_filter)
         with open(workflow_output_file, "w", encoding="utf-8") as f:
             # set indent to 2 for pretty printing
             f.write(workflow_output)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
The eval output_dir can be specified two ways:
```
eval:
  general:
    output_dir: ./.tmp/aiq/examples/simple/
```

(OR)
```
eval:
  general:
    output:
       dir: ./.tmp/aiq/examples/simple/
```
The second is the preferred way as it allows additional output config. However, we maintain the first for backwards compatibility purposes. A previous change broke this compatibility (because of invalid `eval.general.output` access). This PR addresses that issue.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
