### PR TITLE
For remote evaluation, workflow config is not needed

### DIFF
--- a/docs/source/guides/evaluate-api.md
+++ b/docs/source/guides/evaluate-api.md
@@ -41,6 +41,8 @@ aiq serve --config_file=examples/simple/configs/config.yml
 ## Evaluate Request and Response
 The /evaluate endpoint allows you to start an evaluation job. The request is stored for background processing, and the server returns a job ID for tracking the job status.
 
+The `config_file` parameter is the path to the evaluation configuration file on the remote server. Only the `eval` section of the config file is used for evaluation. The `workflow` section is not required. If the `workflow` section is provided, it is instantiated but not used. So it is recommended to not provide a `workflow` section in the evaluation configuration file.
+
 ### Evaluate Request
 - **Route**: `/evaluate`
 - **Method**: `POST`
@@ -51,7 +53,7 @@ curl --request POST \
    --url http://localhost:8000/evaluate \
    --header 'Content-Type: application/json' \
    --data '{
-    "config_file": "examples/simple/configs/eval_config.yml",
+    "config_file": "examples/simple/configs/eval_only_config.yml",
     "expiry_seconds": 600
 }' | jq
 ```
@@ -104,7 +106,7 @@ The response contains the status of the job, including the job ID, status, and a
 {
   "job_id": "882317f0-6149-4b29-872b-9c8018d64784",
   "status": "success",
-  "config_file": "examples/simple/configs/eval_config.yml",
+  "config_file": "examples/simple/configs/eval_only_config.yml",
   "error": null,
   "output_path": ".tmp/aiq/examples/simple/jobs/882317f0-6149-4b29-872b-9c8018d64784",
   "created_at": "2025-04-11T17:33:38.018904Z",
@@ -141,7 +143,7 @@ curl --request GET \
   {
     "job_id": "df6fddd7-2adf-45dd-a105-8559a7569ec9",
     "status": "success",
-    "config_file": "examples/simple/configs/eval_config.yml",
+    "config_file": "examples/simple/configs/eval_only_config.yml",
     "error": null,
     "output_path": ".tmp/aiq/examples/simple/jobs/df6fddd7-2adf-45dd-a105-8559a7569ec9",
     "created_at": "2025-04-11T17:33:16.711636Z",

--- a/examples/simple/src/aiq_simple/configs/eval_only_config.yml
+++ b/examples/simple/src/aiq_simple/configs/eval_only_config.yml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+general:
+  use_uvloop: true
+
+llms:
+  nim_rag_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    max_tokens: 8
+  nim_trajectory_eval_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+
+
+#workflow:
+#  _type: current_datetime
+
+eval:
+  general:
+    output:
+      dir: ./.tmp/aiq/examples/simple/
+      cleanup: true
+    dataset:
+      _type: json
+      file_path: examples/simple/data/langsmith.json
+    profiler:
+      # Compute inter query token uniqueness
+      token_uniqueness_forecast: true
+      # Compute expected workflow runtime
+      workflow_runtime_forecast: true
+      # Compute inference optimization metrics
+      compute_llm_metrics: true
+      # Avoid dumping large text into the output CSV (helpful to not break structure)
+      csv_exclude_io_text: true
+      # Idenitfy common prompt prefixes
+      prompt_caching_prefixes:
+        enable: true
+        min_frequency: 0.1
+      bottleneck_analysis:
+        # Can also be simple_stack
+        enable_nested_stack: true
+      concurrency_spike_analysis:
+        enable: true
+        spike_threshold: 7
+
+  evaluators:
+    rag_accuracy:
+      _type: ragas
+      metric: AnswerAccuracy
+      llm_name: nim_rag_eval_llm
+    rag_groundedness:
+      _type: ragas
+      metric: ResponseGroundedness
+      llm_name: nim_rag_eval_llm
+    rag_relevance:
+      _type: ragas
+      metric: ContextRelevance
+      llm_name: nim_rag_eval_llm
+    trajectory_accuracy:
+      _type: trajectory
+      llm_name: nim_trajectory_eval_llm

--- a/examples/simple/src/aiq_simple/configs/eval_only_config.yml
+++ b/examples/simple/src/aiq_simple/configs/eval_only_config.yml
@@ -28,10 +28,6 @@ llms:
     temperature: 0.0
     max_tokens: 1024
 
-
-#workflow:
-#  _type: current_datetime
-
 eval:
   general:
     output:

--- a/src/aiq/builder/eval_builder.py
+++ b/src/aiq/builder/eval_builder.py
@@ -27,6 +27,7 @@ from aiq.data_models.config import AIQConfig
 from aiq.data_models.config import GeneralConfig
 from aiq.data_models.evaluate import EvalGeneralConfig
 from aiq.data_models.evaluator import EvaluatorBaseConfig
+from aiq.data_models.function import EmptyFunctionConfig
 from aiq.utils.type_utils import override
 
 logger = logging.getLogger(__name__)
@@ -102,7 +103,10 @@ class WorkflowEvalBuilder(WorkflowBuilder, EvalBuilder):
         return tools
 
     async def populate_builder(self, config: AIQConfig):
-        await super().populate_builder(config)
+        # Skip setting workflow if workflow config is EmptyFunctionConfig
+        skip_workflow = True if isinstance(config.workflow, EmptyFunctionConfig) else False
+
+        await super().populate_builder(config, skip_workflow)
         # Instantiate the evaluators
         for name, evaluator_config in config.eval.evaluators.items():
             await self.add_evaluator(name, evaluator_config)

--- a/src/aiq/builder/eval_builder.py
+++ b/src/aiq/builder/eval_builder.py
@@ -104,7 +104,7 @@ class WorkflowEvalBuilder(WorkflowBuilder, EvalBuilder):
 
     async def populate_builder(self, config: AIQConfig):
         # Skip setting workflow if workflow config is EmptyFunctionConfig
-        skip_workflow = True if isinstance(config.workflow, EmptyFunctionConfig) else False
+        skip_workflow = isinstance(config.workflow, EmptyFunctionConfig)
 
         await super().populate_builder(config, skip_workflow)
         # Instantiate the evaluators

--- a/src/aiq/builder/workflow_builder.py
+++ b/src/aiq/builder/workflow_builder.py
@@ -586,7 +586,7 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
     def get_user_manager(self):
         return UserManagerHolder(context=AIQContext(self._context_state))
 
-    async def populate_builder(self, config: AIQConfig):
+    async def populate_builder(self, config: AIQConfig, skip_workflow: bool = False):
 
         # Generate the build sequence
         build_sequence = build_dependency_sequence(config)
@@ -614,7 +614,8 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
                 raise ValueError(f"Unknown component group {component_instance.component_group}")
 
         # Instantiate the workflow
-        await self.set_workflow(config.workflow)
+        if not skip_workflow:
+            await self.set_workflow(config.workflow)
 
     @classmethod
     @asynccontextmanager

--- a/src/aiq/builder/workflow_builder.py
+++ b/src/aiq/builder/workflow_builder.py
@@ -587,7 +587,14 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
         return UserManagerHolder(context=AIQContext(self._context_state))
 
     async def populate_builder(self, config: AIQConfig, skip_workflow: bool = False):
+        """
+        Populate the builder with components and optionally set up the workflow.
 
+        Args:
+            config (AIQConfig): The configuration object containing component definitions.
+            skip_workflow (bool): If True, skips the workflow instantiation step. Defaults to False.
+
+        """
         # Generate the build sequence
         build_sequence = build_dependency_sequence(config)
 


### PR DESCRIPTION
Close #140

You can run evaluation on a remote workflow via the /evaluate endpoint. Two config files are typically used for this -

One to start the workflow (e.g. config.yml) -
```
aiq serve --config_file=examples/simple/configs/config.yml
```
Second to evaluate the already running workflow session (e.g. eval_only_config.yml) -
```
curl --request POST \
   --url http://localhost:8000/evaluate \
   --header 'Content-Type: application/json' \
   --data '{
    "config_file": "examples/simple/configs/eval_only_config.yml",
}' | jq
```
In theory the same config file can be used for both but doing that would result in the the workflow config being instantiated, unnecessarily, everytime the evaluation is run.

There was a limitation that required a workflow section to be present for instantiating the EvalWorkflowBuilder (as it inherits WorkflowBuilder). This PR removes that dependency.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
