### PR TITLE
Remove redundant span stack handling and error logging

### DIFF
--- a/src/aiq/observability/async_otel_listener.py
+++ b/src/aiq/observability/async_otel_listener.py
@@ -191,11 +191,6 @@ class AsyncOtelSpanListener:
 
         self._outstanding_spans.clear()
 
-        if len(self._span_stack) > 0:
-            logger.error(
-                "Not all spans were closed. Ensure all start events have a corresponding end event. Remaining: %s",
-                self._span_stack)
-
         self._span_stack.clear()
 
         # Clean up any lingering Weave calls if Weave is available and initialized
@@ -294,8 +289,6 @@ class AsyncOtelSpanListener:
         if sub_span is None:
             logger.warning("No subspan found for step %s", step.UUID)
             return
-
-        self._span_stack.pop(step.UUID, None)
 
         # Optionally add more attributes from usage_info or data
         usage_info = step.payload.usage_info


### PR DESCRIPTION
The redundant span stack error logging and unused pop operation were removed to streamline the code. These changes reduce unnecessary noise in the logs and improve the clarity of span management logic.

## Description
The redundant span stack error logging and unused pop operation were removed to streamline the code. These changes reduce unnecessary noise in the logs and improve the clarity of span management logic.

Also prevents bug where spans are not logged if multiple subspans use the same parent span sequentially. Previously, as soon as a child span was closed, the parent span was popped from the span stack <- Bug

Closes #232 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
