### PR TITLE
Bugfix for alert triage agent to run in python 3.11

### DIFF
--- a/examples/alert_triage_agent/src/aiq_alert_triage_agent/categorizer.py
+++ b/examples/alert_triage_agent/src/aiq_alert_triage_agent/categorizer.py
@@ -56,10 +56,11 @@ async def categorizer_tool(config: CategorizerToolConfig, builder: Builder):
         # - Add newlines before and after section
         # - Use extracted heading level for consistency
         # - Add extra newline between category and reasoning for readability
-        report_section = f"""\n\n{pound_signs} Root Cause Category\n{result.content.replace('\n', '\n\n')}"""
+        report_content = result.content.replace('\n', '\n\n')
+        report_section = f"""\n\n{pound_signs} Root Cause Category\n{report_content}"""
 
         # Log the result for tracking
-        utils.logger.debug(result.content)
+        utils.logger.debug(report_content)
         utils.log_footer()
 
         return report_section


### PR DESCRIPTION
Addressing an f-string bug. Tested using command: aiq run --config_file=examples/alert_triage_agent/configs/config_test_mode.yml --input 'test'

Run was successful:
2025-05-12 18:48:57,893 - aiq.cli.commands.start - INFO - Starting AIQ Toolkit from config file: 'examples/alert_triage_agent/configs/config_test_mode.yml'
2025-05-12 18:48:58,263 - aiq_alert_triage_agent - INFO - Preloaded test data from: examples/alert_triage_agent/data/test_data.csv
2025-05-12 18:48:58,263 - aiq_alert_triage_agent - INFO - Preloaded benign fallback data from: examples/alert_triage_agent/data/benign_fallback_test_data.json
2025-05-12 18:48:58,263 - aiq_alert_triage_agent - INFO - ==================================================Running in test mode==================================================

Configuration Summary:
--------------------
Workflow Type: alert_triage_agent
Number of Functions: 9
Number of LLMs: 5
Number of Embedders: 0
Number of Memory: 0
Number of Retrievers: 0

2025-05-12 18:48:58,279 - aiq_alert_triage_agent - INFO - Host: [test-instance-0.example.com] is NOT under maintenance according to the maintenance database
2025-05-12 18:50:47,264 - aiq_alert_triage_agent - INFO - Host: [test-instance-1.example.com] is NOT under maintenance according to the maintenance database
2025-05-12 18:51:47,834 - aiq_alert_triage_agent - INFO - Host: [test-instance-2.example.com] is NOT under maintenance according to the maintenance database
2025-05-12 18:52:18,400 - aiq_alert_triage_agent - INFO - Host: [test-instance-3.example.com] is under maintenance according to the maintenance database
2025-05-12 18:52:22,566 - aiq.front_ends.console.console_front_end_plugin - INFO - 
--------------------------------------------------
Workflow Result:
['Successfully processed 4 alerts. Results saved to .tmp/aiq/examples/alert_triage_agent/output/test_output.csv']
Closes