### PR TITLE
Fix environment variable interpolation with console frontend

### DIFF
--- a/src/aiq/cli/cli_utils/config_override.py
+++ b/src/aiq/cli/cli_utils/config_override.py
@@ -23,6 +23,7 @@ import click
 import yaml
 
 from aiq.utils.data_models.schema_validator import validate_yaml
+from aiq.utils.io.yaml_tools import yaml_load
 
 logger = logging.getLogger(__name__)
 
@@ -183,12 +184,9 @@ class LayeredConfig:
 
 def load_and_override_config(config_file: Path, overrides: tuple[tuple[str, str], ...]) -> dict[str, Any]:
     """Load config file and apply any overrides"""
-    # First validate the original config file
-    validate_yaml(None, None, config_file)
 
-    # Load the base config
-    with open(config_file, 'r', encoding='utf-8') as f:
-        base_config = yaml.safe_load(f)
+    # First validate the original config file
+    base_config = yaml_load(config_file)
 
     # Create layered config
     config = LayeredConfig(base_config)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes https://github.com/NVIDIA/AIQToolkit/issues/254

Refactors the `config_override.py` to use the `yaml_load` utility instead of:

```
    # First validate the original config file
    validate_yaml(None, None, config_file)

    # Load the base config
    with open(config_file, 'r', encoding='utf-8') as f:
        base_config = yaml.safe_load(f)
```

This change allows environment variable interpolation to occur before the application proceeds.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/advanced/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
