### PR TITLE
Add linkspector to CI

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -83,8 +83,11 @@ jobs:
         run: ./aiqtoolkit/ci/scripts/github/checks.sh
 
   check-links:
-    name: runner / linkspector
-    runs-on: ubuntu-22.04
+    name: linkspector
+    runs-on: linux-amd64-cpu4
+    timeout-minutes: 15
+    container:
+      image: ubuntu:22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -82,6 +82,22 @@ jobs:
         shell: bash
         run: ./aiqtoolkit/ci/scripts/github/checks.sh
 
+  check-links:
+    name: runner / linkspector
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: 'aiqtoolkit'
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          fail_level: any
+          config_file: ./aiqtoolkit/ci/linkspector.yml
+
   test:
     name: Test
     needs: [check]

--- a/ci/linkspector.yml
+++ b/ci/linkspector.yml
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 dirs:
   - .
 

--- a/ci/linkspector.yml
+++ b/ci/linkspector.yml
@@ -1,0 +1,20 @@
+dirs:
+  - .
+
+excludedFiles:
+  - src/aiq/meta/pypi.md
+
+excludedDirs:
+  - external
+
+ignorePatterns:
+  - pattern: "^https?://localhost:.*$"
+  - pattern: "^https?://$"
+  - pattern: "^https://(platform\\.)?openai\\.com"
+  - pattern: "^https://code\\.visualstudio\\.com$"
+
+replacementPatterns:
+  - pattern: "^https://media.githubusercontent.com/media/NVIDIA/AIQ[Tt]oolkit/refs/heads/main/(.*)$"
+    replacement: "https://media.githubusercontent.com/media/NVIDIA/AIQtoolkit/refs/heads/develop/$1"
+
+useGitIgnore: true

--- a/ci/scripts/documentation_checks.sh
+++ b/ci/scripts/documentation_checks.sh
@@ -14,11 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source ${SCRIPT_DIR}/common.sh
+
 set +e
 
 # Intentionally excluding CHANGELOG.md as it immutable
 DOC_FILES=$(git ls-files "*.md" "*.rst" | grep -v -E '^(CHANGELOG|LICENSE)\.md$' | grep -v -E '^nv_internal/')
 
+echo "Running spelling and grammer checks with Vale"
 vale ${DOC_FILES}
-RETVAL=$?
-exit $RETVAL
+VALE_RETVAL=$?
+
+echo -e "\nRunning link checks with linkspector"
+linkspector check -c ${PROJECT_ROOT}/ci/linkspector.yml
+LINK_RETVAL=$?
+
+if [[ ${PRE_COMMIT_VALE_RETVALRETVAL} -ne 0 || ${LINK_RETVAL} -ne 0 ]]; then
+   echo ">>>> FAILED: checks"
+   exit 1
+fi

--- a/ci/scripts/documentation_checks.sh
+++ b/ci/scripts/documentation_checks.sh
@@ -27,11 +27,13 @@ echo "Running spelling and grammer checks with Vale"
 vale ${DOC_FILES}
 VALE_RETVAL=$?
 
-echo -e "\nRunning link checks with linkspector"
-linkspector check -c ${PROJECT_ROOT}/ci/linkspector.yml
-LINK_RETVAL=$?
+# echo -e "\nRunning link checks with linkspector"
+# linkspector check -c ${PROJECT_ROOT}/ci/linkspector.yml
+# LINK_RETVAL=$?
 
-if [[ ${PRE_COMMIT_VALE_RETVALRETVAL} -ne 0 || ${LINK_RETVAL} -ne 0 ]]; then
-   echo ">>>> FAILED: checks"
-   exit 1
-fi
+# if [[ ${PRE_COMMIT_VALE_RETVALRETVAL} -ne 0 || ${LINK_RETVAL} -ne 0 ]]; then
+#    echo ">>>> FAILED: checks"
+#    exit 1
+# fi
+
+exit ${VALE_RETVAL}

--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -20,6 +20,7 @@ GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
 install_npm
+npm install -g @umbrelladocs/linkspector
 
 create_env group:dev group:docs extra:examples
 

--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -19,8 +19,8 @@ set -e
 GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
-install_npm
-install_linkspector
+# install_npm
+# install_linkspector
 
 create_env group:dev group:docs extra:examples
 

--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -20,7 +20,7 @@ GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
 install_npm
-npm install -g @umbrelladocs/linkspector
+install_linkspector
 
 create_env group:dev group:docs extra:examples
 

--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -19,6 +19,7 @@ set -e
 GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
+install_npm
 
 create_env group:dev group:docs extra:examples
 
@@ -27,7 +28,6 @@ ${SCRIPT_DIR}/checks.sh
 
 rapids-logger "Checking copyright headers"
 python ${SCRIPT_DIR}/copyright.py --verify-apache-v2
-
 
 rapids-logger "Runing Documentation checks"
 ${SCRIPT_DIR}/documentation_checks.sh

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -96,7 +96,7 @@ function install_linkspector() {
 
     # Based on https://github.com/UmbrellaDocs/action-linkspector/blob/main/script.sh which in turn is based on
     # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-    echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    echo 0 | tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 }
 
 rapids-logger "Environment Variables"

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -90,5 +90,14 @@ function install_npm() {
     apt install --no-install-recommends -y npm
 }
 
+function install_linkspector() {
+    rapids-logger "Installing linkspector"
+    npm install -g @umbrelladocs/linkspector@0.4.4
+
+    # Based on https://github.com/UmbrellaDocs/action-linkspector/blob/main/script.sh which in turn is based on
+    # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+    echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+}
+
 rapids-logger "Environment Variables"
 printenv | sort

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -84,5 +84,11 @@ function get_lfs_files() {
     git lfs ls-files
 }
 
+function install_npm() {
+    rapids-logger "Installing npm from apt"
+    apt update
+    apt install --no-install-recommends -y npm
+}
+
 rapids-logger "Environment Variables"
 printenv | sort


### PR DESCRIPTION
## Description
* Currently we use Sphinx's linkcheck builder however this has two draw-backs for us:
  - It only checks documents included in the documentation builds (excluding example and pypi md files)
  - It runs at the end of the CI pipeline rather than at the start of the pipeline.
* linkspector is able to check links in all Markdown files.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
