### PR TITLE
Set mcp-proxy version in the sample Dockerfile to 0.5

### DIFF
--- a/examples/simple_calculator/deploy_external_mcp/Dockerfile
+++ b/examples/simple_calculator/deploy_external_mcp/Dockerfile
@@ -20,7 +20,10 @@ RUN apt-get update && apt-get upgrade -y && apt install -y python3 python3-pip
 
 # Install MCP proxy and tools
 RUN pip3 install uv uvx
-RUN pip3 install "mcp-proxy>=0.5,<0.6"
+
+RUN pip3 install "mcp==1.5.0"
+RUN pip3 install "mcp-proxy==0.5.1"
+
 # Create directory for scripts
 RUN mkdir /scripts
 

--- a/examples/simple_calculator/deploy_external_mcp/Dockerfile
+++ b/examples/simple_calculator/deploy_external_mcp/Dockerfile
@@ -20,8 +20,7 @@ RUN apt-get update && apt-get upgrade -y && apt install -y python3 python3-pip
 
 # Install MCP proxy and tools
 RUN pip3 install uv uvx
-RUN pip3 install mcp-proxy
-
+RUN pip3 install "mcp-proxy>=0.5,<0.6"
 # Create directory for scripts
 RUN mkdir /scripts
 


### PR DESCRIPTION
The latest mcp-proxy==0.6.0 (released two days ago) is resulting in an error -
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
TypeError: 'NoneType' object is not callable
```
```
root@39cdc82e51c1:/# pip list |grep mcp-proxy
mcp-proxy         0.6.0
root@39cdc82e51c1:/#
```

This PR moves back to the last stable release.
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
