### PR TITLE
eval-readme: Add instruction to copy the workflow output before re-runs

### DIFF
--- a/docs/source/reference/evaluate.md
+++ b/docs/source/reference/evaluate.md
@@ -296,15 +296,17 @@ This pass results in workflow interrupted warning. You can then do another pass.
 
 Pass-2:
 ```bash
-aiq eval --config_file=examples/simple/configs/eval_config.yml --skip_completed_entries --dataset=.tmp/aiq/examples/simple/workflow_output.json
+cp .tmp/aiq/examples/simple/workflow_output.json .tmp/simple_workflow_output.json
+aiq eval --config_file=examples/simple/configs/eval_config.yml --skip_completed_entries --dataset=.tmp/simple_workflow_output.json
 ```
 
 ## Running evaluation offline
 You can evaluate a dataset with previously generated answers via the `--skip_workflow` option. In this case the dataset has both the expected `answer` and the `generated_answer`.
 ```bash
-aiq eval --config_file=examples/simple/configs/eval_config.yml --skip_workflow --dataset=.tmp/aiq/examples/simple/workflow_output.json
+cp .tmp/aiq/examples/simple/workflow_output.json .tmp/simple_workflow_output.json
+aiq eval --config_file=examples/simple/configs/eval_config.yml --skip_workflow --dataset=.tmp/simple_workflow_output.json
 ```
-This assumes that the workflow output is previously generated and stored in the `.tmp/aiq/examples/simple/workflow_output.json` file.
+This assumes that the workflow output was previously generated and stored in `.tmp/aiq/examples/simple/workflow_output.json`
 
 ## Running the workflow over a dataset without evaluation
 You can do this by running `aiq eval` with a workflow configuration file that includes an `eval` section with no `evaluators`.


### PR DESCRIPTION
We have changed the default "cleanup" setting to True. So the output_dir contents are removed before the workflow is run again.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
