### PR TITLE
Support additional_instructions

### DIFF
--- a/src/aiq/agent/react_agent/prompt.py
+++ b/src/aiq/agent/react_agent/prompt.py
@@ -35,6 +35,7 @@ Use the following format once you have the final answer:
 Thought: I now know the final answer
 Final Answer: the final answer to the original input question
 """
+
 USER_PROMPT = """
 Question: {question}
 """

--- a/src/aiq/agent/react_agent/prompt.py
+++ b/src/aiq/agent/react_agent/prompt.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 # flake8: noqa
-from langchain_core.prompts.chat import ChatPromptTemplate
-from langchain_core.prompts.chat import MessagesPlaceholder
 
 SYSTEM_PROMPT = """
 Answer the following questions as best you can. You may ask the human to use the following tools:
@@ -40,7 +38,3 @@ Final Answer: the final answer to the original input question
 USER_PROMPT = """
 Question: {question}
 """
-
-# This is the prompt - (ReAct Agent prompt)
-react_agent_prompt = ChatPromptTemplate([("system", SYSTEM_PROMPT), ("user", USER_PROMPT),
-                                         MessagesPlaceholder(variable_name='agent_scratchpad', optional=True)])

--- a/src/aiq/agent/react_agent/register.py
+++ b/src/aiq/agent/react_agent/register.py
@@ -15,6 +15,7 @@
 
 import logging
 
+from langchain_core.prompts import ChatPromptTemplate
 from pydantic import Field
 
 from aiq.agent.base import AGENT_LOG_PREFIX
@@ -59,33 +60,51 @@ class ReActAgentWorkflowConfig(FunctionBaseConfig, name="react_agent"):
         default=None, description="Additional instructions to provide to the agent in addition to the base prompt.")
 
 
+def create_react_agent_prompt(config: ReActAgentWorkflowConfig) -> ChatPromptTemplate:
+    """
+    Create a ReAct Agent prompt from the config.
+
+    Args:
+        config (ReActAgentWorkflowConfig): The config to use for the prompt.
+
+    Returns:
+        ChatPromptTemplate: The ReAct Agent prompt.
+    """
+    # the ReAct Agent prompt comes from prompt.py, and can be customized there or via config option system_prompt.
+    from langchain_core.prompts import MessagesPlaceholder
+
+    from aiq.agent.react_agent.prompt import SYSTEM_PROMPT
+    from aiq.agent.react_agent.prompt import USER_PROMPT
+
+    from .agent import ReActAgentGraph
+
+    if config.system_prompt:
+        _prompt_str = config.system_prompt
+    else:
+        _prompt_str = SYSTEM_PROMPT
+
+    if config.additional_instructions:
+        _prompt_str += f" {config.additional_instructions}"
+
+    valid_prompt = ReActAgentGraph.validate_system_prompt(_prompt_str)
+    if not valid_prompt:
+        logger.exception("%s Invalid system_prompt", AGENT_LOG_PREFIX)
+        raise ValueError("Invalid system_prompt")
+    prompt = ChatPromptTemplate([("system", _prompt_str), ("user", USER_PROMPT),
+                                 MessagesPlaceholder(variable_name='agent_scratchpad', optional=True)])
+    return prompt
+
+
 @register_function(config_type=ReActAgentWorkflowConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builder):
     from langchain.schema import BaseMessage
     from langchain_core.messages import trim_messages
-    from langchain_core.prompts import ChatPromptTemplate
-    from langchain_core.prompts import MessagesPlaceholder
     from langgraph.graph.graph import CompiledGraph
-
-    from aiq.agent.react_agent.prompt import USER_PROMPT
 
     from .agent import ReActAgentGraph
     from .agent import ReActGraphState
-    from .prompt import react_agent_prompt
 
-    # the ReAct Agent prompt comes from prompt.py, and can be customized there or via config option system_prompt.
-    if config.system_prompt:
-        _prompt_str = config.system_prompt
-        if config.additional_instructions:
-            _prompt_str += f" {config.additional_instructions}"
-        valid_prompt = ReActAgentGraph.validate_system_prompt(config.system_prompt)
-        if not valid_prompt:
-            logger.exception("%s Invalid system_prompt", AGENT_LOG_PREFIX)
-            raise ValueError("Invalid system_prompt")
-        prompt = ChatPromptTemplate([("system", config.system_prompt), ("user", USER_PROMPT),
-                                     MessagesPlaceholder(variable_name='agent_scratchpad', optional=True)])
-    else:
-        prompt = react_agent_prompt
+    prompt = create_react_agent_prompt(config)
 
     # we can choose an LLM for the ReAct agent in the config file
     llm = await builder.get_llm(config.llm_name, wrapper_type=LLMFrameworkEnum.LANGCHAIN)

--- a/tests/aiq/agent/test_react.py
+++ b/tests/aiq/agent/test_react.py
@@ -25,13 +25,13 @@ from aiq.agent.react_agent.agent import NO_INPUT_ERROR_MESSAGE
 from aiq.agent.react_agent.agent import TOOL_NOT_FOUND_ERROR_MESSAGE
 from aiq.agent.react_agent.agent import ReActAgentGraph
 from aiq.agent.react_agent.agent import ReActGraphState
+from aiq.agent.react_agent.agent import create_react_agent_prompt
 from aiq.agent.react_agent.output_parser import FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE
 from aiq.agent.react_agent.output_parser import MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE
 from aiq.agent.react_agent.output_parser import MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE
 from aiq.agent.react_agent.output_parser import ReActOutputParser
 from aiq.agent.react_agent.output_parser import ReActOutputParserException
 from aiq.agent.react_agent.register import ReActAgentWorkflowConfig
-from aiq.agent.react_agent.register import create_react_agent_prompt
 
 
 async def test_state_schema():

--- a/tests/aiq/agent/test_react.py
+++ b/tests/aiq/agent/test_react.py
@@ -424,8 +424,6 @@ def test_react_additional_instructions(mock_llm, mock_tool):
     prompt = create_react_agent_prompt(config_react_agent)
     agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=config_react_agent.verbose)
     assert isinstance(agent, ReActAgentGraph)
-    print(dir(agent.agent))
-    print(agent.agent.get_prompts())
     assert "Talk like a parrot" in agent.agent.get_prompts()[0].messages[0].prompt.template
 
 

--- a/tests/aiq/agent/test_react.py
+++ b/tests/aiq/agent/test_react.py
@@ -30,8 +30,8 @@ from aiq.agent.react_agent.output_parser import MISSING_ACTION_AFTER_THOUGHT_ERR
 from aiq.agent.react_agent.output_parser import MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE
 from aiq.agent.react_agent.output_parser import ReActOutputParser
 from aiq.agent.react_agent.output_parser import ReActOutputParserException
-from aiq.agent.react_agent.prompt import react_agent_prompt
 from aiq.agent.react_agent.register import ReActAgentWorkflowConfig
+from aiq.agent.react_agent.register import create_react_agent_prompt
 
 
 async def test_state_schema():
@@ -59,7 +59,7 @@ def mock_config():
 
 def test_react_init(mock_config_react_agent, mock_llm, mock_tool):
     tools = [mock_tool('Tool A'), mock_tool('Tool B')]
-    prompt = react_agent_prompt
+    prompt = create_react_agent_prompt(mock_config_react_agent)
     agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=mock_config_react_agent.verbose)
     assert isinstance(agent, ReActAgentGraph)
     assert agent.llm == mock_llm
@@ -72,7 +72,7 @@ def test_react_init(mock_config_react_agent, mock_llm, mock_tool):
 @pytest.fixture(name='mock_react_agent', scope="module")
 def mock_agent(mock_config_react_agent, mock_llm, mock_tool):
     tools = [mock_tool('Tool A'), mock_tool('Tool B')]
-    prompt = react_agent_prompt
+    prompt = create_react_agent_prompt(mock_config_react_agent)
     agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=mock_config_react_agent.verbose)
     return agent
 
@@ -412,3 +412,32 @@ async def test_output_parser_missing_action_input(mock_react_output_parser):
         await mock_react_output_parser.aparse(mock_input)
     assert isinstance(ex.value, ReActOutputParserException)
     assert ex.value.observation == MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE
+
+
+def test_react_additional_instructions(mock_llm, mock_tool):
+    config_react_agent = ReActAgentWorkflowConfig(tool_names=['test'],
+                                                  llm_name='test',
+                                                  verbose=True,
+                                                  retry_parsing_errors=False,
+                                                  additional_instructions="Talk like a parrot and repeat the question.")
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(config_react_agent)
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=config_react_agent.verbose)
+    assert isinstance(agent, ReActAgentGraph)
+    print(dir(agent.agent))
+    print(agent.agent.get_prompts())
+    assert "Talk like a parrot" in agent.agent.get_prompts()[0].messages[0].prompt.template
+
+
+def test_react_custom_system_prompt(mock_llm, mock_tool):
+    config_react_agent = ReActAgentWorkflowConfig(
+        tool_names=['test'],
+        llm_name='test',
+        verbose=True,
+        retry_parsing_errors=False,
+        system_prompt="Refuse to run any of the following tools: {tools}.  or ones named: {tool_names}")
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(config_react_agent)
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=config_react_agent.verbose)
+    assert isinstance(agent, ReActAgentGraph)
+    assert "Refuse" in agent.agent.get_prompts()[0].messages[0].prompt.template


### PR DESCRIPTION
## Description

React agent supports additional_instructions configuration option.  
Add test cases for custom system prompt and adding additional_instructions.

<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #301

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
