### PR TITLE
fix mcp client schema creation in flat lists

### DIFF
--- a/src/aiq/tool/mcp/mcp_client.py
+++ b/src/aiq/tool/mcp/mcp_client.py
@@ -63,9 +63,9 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
         elif json_type == "array" and "items" in field_properties:
             item_properties = field_properties.get("items", {})
             if item_properties.get("type") == "object":
-                item_type = model_from_mcp_schema(name=field_name, mcp_input_schema=field_properties)
+                item_type = model_from_mcp_schema(name=field_name, mcp_input_schema=item_properties)
             else:
-                item_type = _type_map.get(json_type, Any)
+                item_type = _type_map.get(item_properties.get("type", "string"), Any)
             field_type = list[item_type]
         else:
             field_type = _type_map.get(json_type, Any)

--- a/tests/aiq/tools/test_mcp.py
+++ b/tests/aiq/tools/test_mcp.py
@@ -63,6 +63,12 @@ def _get_sample_schema():
             },
             'optional_bool_field': {
                 'default': False, 'description': 'Optional Boolean Field.', 'title': 'Raw', 'type': 'boolean'
+            },
+            'optional_array_field': {
+                'default': ['item'], 'description': 'Optional Array Field.', 'title': 'Array', 'type': 'array', 'items': {'type': 'string'}
+            },
+            'optional_array_object_field': {
+                'default': [{'key': 'value'}], 'description': 'Optional Array Field.', 'title': 'Array', 'type': 'array', 'items': {'type': 'object', 'properties': {'key': {'type': 'string'}}}
             }
         },
         'required': [
@@ -100,6 +106,8 @@ def test_schema_generation(sample_schema):
         "required_string_field": "This is a string",
         "required_int_field": 4,
         "required_float_field": 5.5,
+        "optional_array_field": ["item1"],
+        "optional_array_object_field": [{'key': 'value1'}],
     }
 
     m = _model.model_validate(test_input)

--- a/tests/aiq/tools/test_mcp.py
+++ b/tests/aiq/tools/test_mcp.py
@@ -65,10 +65,28 @@ def _get_sample_schema():
                 'default': False, 'description': 'Optional Boolean Field.', 'title': 'Raw', 'type': 'boolean'
             },
             'optional_array_field': {
-                'default': ['item'], 'description': 'Optional Array Field.', 'title': 'Array', 'type': 'array', 'items': {'type': 'string'}
+                'default': ['item'],
+                'description': 'Optional Array Field.',
+                'title': 'Array',
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                }
             },
             'optional_array_object_field': {
-                'default': [{'key': 'value'}], 'description': 'Optional Array Field.', 'title': 'Array', 'type': 'array', 'items': {'type': 'object', 'properties': {'key': {'type': 'string'}}}
+                'default': [{
+                    'key': 'value'
+                }],
+                'description': 'Optional Array Field.',
+                'title': 'Array',
+                'type': 'array',
+                'items': {
+                    'type': 'object', 'properties': {
+                        'key': {
+                            'type': 'string'
+                        }
+                    }
+                }
             }
         },
         'required': [
@@ -107,7 +125,9 @@ def test_schema_generation(sample_schema):
         "required_int_field": 4,
         "required_float_field": 5.5,
         "optional_array_field": ["item1"],
-        "optional_array_object_field": [{'key': 'value1'}],
+        "optional_array_object_field": [{
+            'key': 'value1'
+        }],
     }
 
     m = _model.model_validate(test_input)


### PR DESCRIPTION
## Description

For MCP tools that have an input that is a flat list, eg 

```
{
  'items': ['item', 'item']
}
```

The original code led to an invalid pydantic schema like this: 

```
{
    'items': {'items': {}, 'type': 'array'},
    'type': 'array'
}
```

Now the schema is correctly created like this:

```
{
    'items': {'type': 'string'},
    'type': 'array'
}
```

Confirmed the fix using a JIRA MCP tool.

Closes #342 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
