### PR TITLE
Provide a config to pass the complete dataset entry as an EvalInputItem field to evaluators

### DIFF
--- a/docs/source/reference/evaluate.md
+++ b/docs/source/reference/evaluate.md
@@ -87,6 +87,20 @@ eval:
         disable: true
 ```
 
+### Passing the Full Dataset Entry to the Evaluator
+In some evaluation scenarios, you may have additional fields in your dataset that are not consumed by the workflow but are required by the evaluator (e.g., metadata, references, or labels). To make these fields available during evaluation, enable the `pass_full_entry` option in your dataset configuration.
+
+When `eval.general.dataset.pass_full_entry` is set to true, the entire dataset entry is passed as a dictionary to the evaluator via the `full_dataset_entry` field in the `EvalInputItem` object.
+
+**Example:**
+```yaml
+eval:
+  general:
+    dataset:
+      pass_full_entry: true
+```
+This is useful for custom evaluators that require access to fields like `reference_answers` or `metadata` which are not part of the workflow's inputs but are relevant for scoring or analysis.
+
 ### Filtering Datasets
 While evaluating large datasets, you can filter the dataset to a
 smaller subset by allowing or denying entries with the `eval.general.dataset.filter`

--- a/src/aiq/data_models/dataset_handler.py
+++ b/src/aiq/data_models/dataset_handler.py
@@ -59,6 +59,7 @@ class EvalDatasetStructureConfig(BaseModel):
 class EvalDatasetBaseConfig(TypedBaseModel, BaseModelRegistryTag):
 
     id_key: str = "id"
+    pass_full_entry: bool = False  # pass the full entry to the evaluator
     structure: EvalDatasetStructureConfig = EvalDatasetStructureConfig()
 
     # Filters

--- a/src/aiq/eval/dataset_handler/dataset_handler.py
+++ b/src/aiq/eval/dataset_handler/dataset_handler.py
@@ -81,6 +81,7 @@ class DatasetHandler:
                 output_obj=row.get(self.generated_answer_key, "") if structured else "",
                 trajectory=row.get(self.trajectory_key, []) if structured else [],
                 expected_trajectory=row.get(self.expected_trajectory_key, []) if structured else [],
+                full_dataset_entry=row.to_dict() if self.dataset_config.pass_full_entry else None,
             )
 
         # if input dataframe is empty return an empty list

--- a/src/aiq/eval/evaluator/evaluator_model.py
+++ b/src/aiq/eval/evaluator/evaluator_model.py
@@ -27,6 +27,7 @@ class EvalInputItem(BaseModel):
     output_obj: typing.Any
     expected_trajectory: list[IntermediateStep]
     trajectory: list[IntermediateStep]
+    full_dataset_entry: typing.Any
 
 
 class EvalInput(BaseModel):

--- a/tests/aiq/eval/dataset_handler/test_dataset_handler.py
+++ b/tests/aiq/eval/dataset_handler/test_dataset_handler.py
@@ -79,6 +79,32 @@ def input_entry_two(dataset_id_key, dataset_structure):
 
 
 @pytest.fixture
+def input_entry_with_extras(dataset_id_key, dataset_structure):
+    """Mock input entry with additional fields."""
+    return {
+        dataset_id_key: "3",
+        dataset_structure.question_key: "What is NLP?",
+        dataset_structure.answer_key: "Natural Language Processing",
+        dataset_structure.generated_answer_key: "NLP",
+        dataset_structure.trajectory_key: [],
+        dataset_structure.expected_trajectory_key: [],
+        "additional_field": "additional_value",
+        "additional_field_2": 123,
+        "additional_field_3": True,
+        "additional_field_4": [1, 2, 3],
+        "additional_field_5": {
+            "key": "value"
+        }
+    }
+
+
+@pytest.fixture
+def mock_input_df_with_extras(input_entry_with_extras):
+    """Mock DataFrame with additional fields."""
+    return pd.DataFrame([input_entry_with_extras])
+
+
+@pytest.fixture
 def mock_input_df(input_entry_one, input_entry_two):
     """Mock DataFrame with sample dataset."""
     return pd.DataFrame([input_entry_one, input_entry_two])
@@ -118,6 +144,33 @@ def mock_swe_bench_input_df(dataset_swe_bench_id_key):
     }, {
         dataset_swe_bench_id_key: "bar_2", "problem": "Overflow", "repo": "bar"
     }])
+
+
+@pytest.mark.parametrize("pass_full_entry", [True, False])
+def test_get_eval_input_from_df_with_additional_fields(mock_input_df_with_extras,
+                                                       input_entry_with_extras,
+                                                       pass_full_entry,
+                                                       dataset_id_key,
+                                                       dataset_structure):
+    """
+    Test that additional fields are passed to the evaluator if dataset config has
+    pass_full_entry set to true.
+    """
+    dataset_config = EvalDatasetJsonConfig(pass_full_entry=pass_full_entry)
+    dataset_handler = DatasetHandler(dataset_config, reps=1)
+    eval_input = dataset_handler.get_eval_input_from_df(mock_input_df_with_extras)
+
+    # check core fields
+    assert eval_input.eval_input_items[0].id == input_entry_with_extras[dataset_id_key]
+    assert eval_input.eval_input_items[0].input_obj == input_entry_with_extras[dataset_structure.question_key]
+    assert eval_input.eval_input_items[0].expected_output_obj == input_entry_with_extras[dataset_structure.answer_key]
+    assert eval_input.eval_input_items[0].expected_trajectory == input_entry_with_extras[
+        dataset_structure.expected_trajectory_key]
+
+    if pass_full_entry:
+        assert eval_input.eval_input_items[0].full_dataset_entry == input_entry_with_extras
+    else:
+        assert eval_input.eval_input_items[0].full_dataset_entry is None
 
 
 def test_get_eval_input_from_df(dataset_handler,


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
